### PR TITLE
Fix: wi-list-entries not returning when book name specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -2718,7 +2718,7 @@ SlashCommandParser.addCommandObject(SlashCommand.fromProps({ name: 'wi-list-entr
         let names;
         let isNameGiven = false;
         if (unnamedArgs.length && unnamedArgs[0]?.trim()?.length && unnamedArgs[0] != '""' && unnamedArgs[0] != 'null') {
-            names = [unnamedArgs[0].trim()];
+            names = [unnamedArgs.trim()];
             isNameGiven = true;
         } else {
             names = getBookNames();


### PR DESCRIPTION
When the command was being fired it was only sending the first letter of the unnamed variable.